### PR TITLE
Refactor array pre-sizing after clear

### DIFF
--- a/addons/sourcemod/scripting/nt_competitive_clantag_updater.sp
+++ b/addons/sourcemod/scripting/nt_competitive_clantag_updater.sp
@@ -451,11 +451,11 @@ and team tag must be at least %d characters long \
 	return num_clans;
 }
 
-static int ClansArrayListPreallocSize()
+static int ClansArrayFiltersPreallocSize()
 {
 	if (g_rClans == null)
 	{
-		LogError("Requested ClansArrayListPreallocSize while g_rClans == null");
+		LogError("Requested ClansArrayFiltersPreallocSize while g_rClans == null");
 		return 0;
 	}
 	// Preallocate for teams + 3 for sorting + 3 for the "header fields".
@@ -497,7 +497,7 @@ void UpdateTeamNames(bool force = false)
 	for (int team = TEAM_JINRAI; team <= TEAM_NSF; ++team)
 	{
 		filters.Clear();
-		filters.Resize(ClansArrayListPreallocSize());
+		filters.Resize(ClansArrayFiltersPreallocSize());
 
 		filters.Set(0, 3); // Size of the "headers" data
 		filters.Set(1, team);  // Only look for members in this team
@@ -672,7 +672,7 @@ int SortClans(int index1, int index2, Handle array, Handle filters)
 	}
 
 	// Write in-place if it fits
-	if (num_indices_used < ClansArrayListPreallocSize())
+	if (num_indices_used < ClansArrayFiltersPreallocSize())
 	{
 		view_as<ArrayList>(filters).Set(num_indices_used, push_result);
 	}

--- a/addons/sourcemod/scripting/nt_competitive_clantag_updater.sp
+++ b/addons/sourcemod/scripting/nt_competitive_clantag_updater.sp
@@ -516,7 +516,10 @@ void UpdateTeamNames(bool force = false)
 		SortADTArrayCustom(filters, SortFilters, filters);
 
 		// Amount of clan members in the top sorted team.
-		if (filters.Length == 0 || filters.Get(0) == 0)
+		// Subtracting the "header" data length from the filters.Length check,
+		// because we're interested in the size of the sorted team data,
+		// not the size of the entire container.
+		if ((filters.Length - 3) <= 0 || filters.Get(0) == 0)
 		{
 			// If we got none, the team has no clan in it.
 			continue;
@@ -563,15 +566,17 @@ void UpdateTeamNames(bool force = false)
 // This is a descending integer sort, but we ignore the "header" fields
 // in the container's 0-3 (inclusive) range.
 //
-// We use this custom sort because otherwise we'd have to remove the header
+// Using this custom sort because otherwise we'd have to remove the header
 // data from the beginning of the container, which would involve moving
-// the entire container's memory, which is slower.
+// the entire container's memory (which is slow).
 //
 // Returns: qsort return value
 int SortFilters(int index1, int index2, Handle array, Handle filters)
 {
+	// 0-3 (inclusive) is the header range we want to ignore.
 	if (NumInRange(index1, 0, 3))
 	{
+		// Favour whichever index is not in header range, or don't reorder otherwise.
 		return NumInRange(index2, 0, 3) ? 0 : index2;
 	}
 	else if (NumInRange(index2, 0, 3))

--- a/addons/sourcemod/scripting/nt_competitive_clantag_updater.sp
+++ b/addons/sourcemod/scripting/nt_competitive_clantag_updater.sp
@@ -497,9 +497,9 @@ void UpdateTeamNames(bool force = false)
 	for (int team = TEAM_JINRAI; team <= TEAM_NSF; ++team)
 	{
 		filters.Clear();
+		filters.Resize(ClansArrayListPreallocSize());
 
-		filters.Resize(g_rClans.Length + 6);
-		filters.Set(0, ClansArrayListPreallocSize());
+		filters.Set(0, 3); // Size of the "headers" data
 		filters.Set(1, team);  // Only look for members in this team
 		filters.SetString(2, ignore_clan);  // Don't look for this clan (skipped if empty)
 		SortADTArrayCustom(g_rClans, SortClans, filters);
@@ -547,8 +547,7 @@ void UpdateTeamNames(bool force = false)
 			// Only announce new team name if it was actually changed.
 			if (!StrEqual(((team == TEAM_NSF) ? previous_team_name_nsf : previous_team_name_jinrai), clan.name))
 			{
-				ConVar team_cvar = (team == TEAM_NSF) ? g_hCvar_NsfName : g_hCvar_JinraiName;
-				team_cvar.SetString(clan.name);
+				SetConVarString((team == TEAM_NSF) ? g_hCvar_NsfName : g_hCvar_JinraiName, clan.name);
 				PrintToChatAll("%s Detected a team in %s. Setting the team name as: %s",
 					g_sTag,
 					(team == TEAM_NSF) ? "NSF" : "Jinrai",


### PR DESCRIPTION
Fix the ADT array pre-sizing getting undone on array clear, leading to unoptimal memory copies.

TODO:

- [ ] Verify this doesn't change behaviour
- [ ] Benchmark